### PR TITLE
Implement sea import settlement feature

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,7 +1,8 @@
 import { Module } from '@nestjs/common';
 import { AirImportModule } from './modules/air-import/air-import.module';
+import { SeaImportModule } from './modules/sea-import/sea-import.module';
 
 @Module({
-  imports: [AirImportModule],
+  imports: [AirImportModule, SeaImportModule],
 })
 export class AppModule {}

--- a/src/application/use-cases/calculate-settlement.usecase.ts
+++ b/src/application/use-cases/calculate-settlement.usecase.ts
@@ -1,0 +1,80 @@
+import { Injectable } from '@nestjs/common';
+import { SettlementRepository } from '../../domain/repositories/settlement.repository';
+import { Settlement, SettlementDetail } from '../../domain/entities/settlement.entity';
+
+export interface CalculateSettlementInput {
+  currency: 'KRW' | 'FOREIGN';
+  exchangeRate: number; // foreign per KRW
+  duty: number;
+  vat: number;
+  warehousing: number;
+  warehousingVat: number;
+  freight: number;
+}
+
+export interface CalculateSettlementOutput {
+  totalKrw: number;
+  totalForeign: number;
+}
+
+@Injectable()
+export class CalculateSettlementUseCase {
+  constructor(private readonly repo: SettlementRepository) {}
+
+  async execute(input: CalculateSettlementInput): Promise<CalculateSettlementOutput> {
+    const rate = input.exchangeRate;
+    const wh = input.warehousing * 1.1; // add 10%
+    const freight = input.freight * 1.1; // add 10%
+
+    const toForeign = (krw: number) => parseFloat((krw / rate).toFixed(2));
+    const toKrw = (foreign: number) => parseFloat((foreign * rate).toFixed(2));
+
+    let dutyKrw: number, dutyForeign: number;
+    let vatKrw: number, vatForeign: number;
+    let whKrw: number, whForeign: number;
+    let whVatKrw: number, whVatForeign: number;
+    let freightKrw: number, freightForeign: number;
+
+    if (input.currency === 'KRW') {
+      dutyKrw = input.duty;
+      vatKrw = input.vat;
+      whKrw = wh;
+      whVatKrw = input.warehousingVat;
+      freightKrw = freight;
+
+      dutyForeign = toForeign(dutyKrw);
+      vatForeign = toForeign(vatKrw);
+      whForeign = toForeign(whKrw);
+      whVatForeign = toForeign(whVatKrw);
+      freightForeign = toForeign(freightKrw);
+    } else {
+      dutyForeign = input.duty;
+      vatForeign = input.vat;
+      whForeign = wh;
+      whVatForeign = input.warehousingVat;
+      freightForeign = freight;
+
+      dutyKrw = toKrw(dutyForeign);
+      vatKrw = toKrw(vatForeign);
+      whKrw = toKrw(whForeign);
+      whVatKrw = toKrw(whVatForeign);
+      freightKrw = toKrw(freightForeign);
+    }
+
+    const details: SettlementDetail[] = [
+      { id: 'duty', description: 'Duty', krwAmount: dutyKrw, foreignAmount: dutyForeign },
+      { id: 'vat', description: 'VAT', krwAmount: vatKrw, foreignAmount: vatForeign },
+      { id: 'wh', description: 'Warehousing', krwAmount: whKrw, foreignAmount: whForeign },
+      { id: 'whVat', description: 'Warehousing VAT', krwAmount: whVatKrw, foreignAmount: whVatForeign },
+      { id: 'freight', description: 'Freight', krwAmount: freightKrw, foreignAmount: freightForeign },
+    ];
+
+    const totalKrw = dutyKrw + vatKrw + whKrw + whVatKrw + freightKrw;
+    const totalForeign = dutyForeign + vatForeign + whForeign + whVatForeign + freightForeign;
+
+    const settlement = new Settlement(Date.now().toString(), totalKrw, totalForeign, details);
+    await this.repo.save(settlement);
+
+    return { totalKrw, totalForeign };
+  }
+}

--- a/src/domain/entities/settlement.entity.ts
+++ b/src/domain/entities/settlement.entity.ts
@@ -1,0 +1,15 @@
+export interface SettlementDetail {
+  id: string;
+  description: string;
+  krwAmount: number;
+  foreignAmount: number;
+}
+
+export class Settlement {
+  constructor(
+    public readonly id: string,
+    public readonly totalKrw: number,
+    public readonly totalForeign: number,
+    public readonly details: SettlementDetail[],
+  ) {}
+}

--- a/src/domain/repositories/settlement.repository.ts
+++ b/src/domain/repositories/settlement.repository.ts
@@ -1,0 +1,6 @@
+import { Settlement } from '../entities/settlement.entity';
+
+export interface SettlementRepository {
+  save(settlement: Settlement): Promise<void>;
+  findAll(): Promise<Settlement[]>;
+}

--- a/src/infrastructure/persistence/in-memory/settlement.repository.impl.ts
+++ b/src/infrastructure/persistence/in-memory/settlement.repository.impl.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@nestjs/common';
+import { SettlementRepository } from '../../../domain/repositories/settlement.repository';
+import { Settlement } from '../../../domain/entities/settlement.entity';
+
+@Injectable()
+export class InMemorySettlementRepository implements SettlementRepository {
+  private settlements: Settlement[] = [];
+
+  async save(settlement: Settlement): Promise<void> {
+    this.settlements.push(settlement);
+  }
+
+  async findAll(): Promise<Settlement[]> {
+    return this.settlements;
+  }
+}

--- a/src/modules/sea-import/controllers/settlement.controller.ts
+++ b/src/modules/sea-import/controllers/settlement.controller.ts
@@ -1,0 +1,13 @@
+import { Body, Controller, Post } from '@nestjs/common';
+import { CalculateSettlementUseCase } from '../../../application/use-cases/calculate-settlement.usecase';
+import { CalculateSettlementInput } from '../../../application/use-cases/calculate-settlement.usecase';
+
+@Controller('sea-import/settlement')
+export class SettlementController {
+  constructor(private readonly calculate: CalculateSettlementUseCase) {}
+
+  @Post()
+  async create(@Body() body: CalculateSettlementInput) {
+    return this.calculate.execute(body);
+  }
+}

--- a/src/modules/sea-import/sea-import.module.ts
+++ b/src/modules/sea-import/sea-import.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { SettlementController } from './controllers/settlement.controller';
+import { InMemorySettlementRepository } from '../../infrastructure/persistence/in-memory/settlement.repository.impl';
+import { CalculateSettlementUseCase } from '../../application/use-cases/calculate-settlement.usecase';
+
+@Module({
+  controllers: [SettlementController],
+  providers: [
+    InMemorySettlementRepository,
+    { provide: 'SettlementRepository', useExisting: InMemorySettlementRepository },
+    CalculateSettlementUseCase,
+  ],
+})
+export class SeaImportModule {}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,8 @@
     "target": "es2017",
     "rootDir": "src",
     "outDir": "dist",
-    "strict": true
+    "strict": true,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true
   }
 }


### PR DESCRIPTION
## Summary
- add Settlement entity and repository
- create use case to calculate settlement amounts
- implement in-memory persistence for settlements
- expose settlement POST endpoint in new SeaImport module
- enable decorators in tsconfig

## Testing
- `npx tsc -p tsconfig.json` *(fails: Cannot find module '@nestjs/common')*

------
https://chatgpt.com/codex/tasks/task_e_68736a9db410832abe6530fa4d6af301